### PR TITLE
Fix Tempest command permissions when permissions are disabled

### DIFF
--- a/Class1.cs
+++ b/Class1.cs
@@ -54,12 +54,17 @@ namespace ARC_TPA_Commands
 
         internal static List<string> ResolvePermissions(List<string> requiredPermissions)
         {
-            if (PermissionsEnabled)
+            if (!PermissionsEnabled)
             {
-                return requiredPermissions ?? new List<string>();
+                // Returning null signals to RocketMod that the command requires no
+                // specific permission nodes. Supplying an empty list incorrectly
+                // causes RocketMod to fall back to its default permission checks,
+                // which prevents non-owners from executing the Tempest commands
+                // when permissions are globally disabled.
+                return null;
             }
 
-            return new List<string>();
+            return requiredPermissions ?? new List<string>();
         }
 
         protected override void Load()


### PR DESCRIPTION
## Summary
- return null from ResolvePermissions when permissions are disabled so RocketMod treats Tempest commands as public
- prevent non-owner players from being blocked by fallback permission checks when Use_Permissions is false

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2c9eb115883248b7ac655e8b719b9