### PR TITLE
Add Codex live telemetry sync pipeline

### DIFF
--- a/ARC_TPA_Commands.csproj
+++ b/ARC_TPA_Commands.csproj
@@ -45,7 +45,9 @@
     <Reference Include="System.Data"/>
     
     <Reference Include="System.Net.Http"/>
-    
+
+    <Reference Include="System.Web.Extensions"/>
+
     <Reference Include="System.Xml"/>
 
 

--- a/Class1.cs
+++ b/Class1.cs
@@ -38,6 +38,8 @@ namespace ARC_TPA_Commands
         public ushort Map_Refresh_Interval_Seconds;
         public ushort Map_Player_Stale_Minutes;
         public string Map_Share_Url;
+        public string Map_Live_Api_Url;
+        public string Map_Live_Api_Key;
 
         public void LoadDefaults()
         {
@@ -53,6 +55,8 @@ namespace ARC_TPA_Commands
             Map_Refresh_Interval_Seconds = 5;
             Map_Player_Stale_Minutes = 2;
             Map_Share_Url = "https://tempest.arcfoundation.net/map";
+            Map_Live_Api_Url = "https://codex.tempest.arcfoundation.net/api/unturned/live";
+            Map_Live_Api_Key = "ChangeMe!";
         }
     }
 

--- a/tempest-map/README.md
+++ b/tempest-map/README.md
@@ -10,10 +10,18 @@ cp .env.example .env.local
 npm run dev
 ```
 
-The development server runs on <http://localhost:3000> by default. The tactical map API connects to a local SQLite database. By
- default a database file is created at `./data/tempest-map.db` the first time the API is called and is seeded with sample
- telemetry. Adjust `TEMPEST_MAP_DB_PATH` in `.env.local` if you want to use a different location or point the site at a
- production database that is populated by the Tempest plugin.
+The development server runs on <http://localhost:3000> by default. Configure the following environment variables to connect both the ingest API and the tactical UI to your MySQL instance:
+
+```
+MYSQL_HOST=127.0.0.1
+MYSQL_PORT=3306
+MYSQL_USER=tempest
+MYSQL_PASSWORD=ChangeMe!
+MYSQL_DATABASE=tempest_map
+LIVE_SYNC_SERVER_KEY=ChangeMe!
+```
+
+The Rocket plugin will stream telemetry to `POST /api/unturned/live` with the `X-Server-Key` header set to `LIVE_SYNC_SERVER_KEY`. The Next.js `GET /api/live` endpoint (and the `/map` page) query the same database to power the Leaflet dashboard.
 
 ## Available scripts
 
@@ -25,7 +33,8 @@ The development server runs on <http://localhost:3000> by default. The tactical 
 ## Architecture highlights
 
 - **App Router** with server components for fast initial loads and streaming updates.
-- **Better SQLite3** for zero-ORM access to the telemetry tables populated by the Tempest plugin.
+- **MySQL-backed Codex API** for ingesting live telemetry directly from the Tempest plugin.
+- **Leaflet + React Leaflet** to render the live tactical picture with smooth refreshes.
 - **Tailwind CSS 4** design system with neon-accented tactical visuals.
 - Graceful fallbacks when the database is unavailable (mock telemetry keeps the UI alive).
 

--- a/tempest-map/app/api/live/route.ts
+++ b/tempest-map/app/api/live/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { fetchPlayerSnapshot } from "@/lib/positions";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const snapshot = await fetchPlayerSnapshot();
+    return NextResponse.json(snapshot, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    console.error("[TempestMap] Live API error", error);
+    return NextResponse.json({ error: "Failed to fetch live telemetry" }, { status: 500 });
+  }
+}

--- a/tempest-map/app/api/unturned/live/route.ts
+++ b/tempest-map/app/api/unturned/live/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDatabase } from "@/lib/db";
+import { ensureLiveSchema } from "@/lib/schema";
+import type { PoolConnection } from "mysql2/promise";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type IncomingPlayer = {
+  steamId: string;
+  characterName: string;
+  groupName?: string | null;
+  position: { x: number; y: number; z: number };
+  rotationY: number;
+  health: number;
+  isOnline: boolean;
+  lastSeenUtc?: string;
+};
+
+type IncomingPayload = {
+  capturedAt?: string;
+  map?: { name?: string; levelSize?: number; shareUrl?: string | null };
+  players?: IncomingPlayer[];
+};
+
+function parseDate(value: string | undefined, fallback: Date): Date {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+}
+
+function sanitisePlayer(player: IncomingPlayer, fallbackDate: Date) {
+  const lastSeen = parseDate(player.lastSeenUtc, fallbackDate);
+  return {
+    steamId: typeof player.steamId === "string" ? player.steamId : String(player.steamId ?? ""),
+    characterName: player.characterName?.trim().length ? player.characterName.trim() : "Unknown Survivor",
+    groupName: player.groupName && player.groupName.trim().length > 0 ? player.groupName.trim() : null,
+    position: {
+      x: toNumber(player.position?.x, 0),
+      y: toNumber(player.position?.y, 0),
+      z: toNumber(player.position?.z, 0)
+    },
+    rotationY: toNumber(player.rotationY, 0),
+    health: Math.max(0, Math.min(100, Math.round(toNumber(player.health, 0)))),
+    isOnline: Boolean(player.isOnline),
+    lastSeenUtc: lastSeen.toISOString()
+  };
+}
+
+async function persistSnapshot(connection: PoolConnection, payload: IncomingPayload) {
+  await ensureLiveSchema(connection);
+
+  const capturedAt = parseDate(payload.capturedAt, new Date());
+  const mapName = payload.map?.name?.trim().length ? payload.map.name.trim() : "Unknown";
+  const levelSize = Math.max(1, Math.round(toNumber(payload.map?.levelSize, 4096)));
+  const shareUrl = payload.map?.shareUrl?.trim().length ? payload.map.shareUrl?.trim() ?? null : null;
+
+  await connection.execute(
+    `INSERT INTO map_state (id, map_name, level_size, last_synced_utc, share_url)
+     VALUES (1, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       map_name = VALUES(map_name),
+       level_size = VALUES(level_size),
+       last_synced_utc = VALUES(last_synced_utc),
+       share_url = VALUES(share_url)`,
+    [mapName, levelSize, capturedAt.toISOString().slice(0, 19).replace("T", " "), shareUrl]
+  );
+
+  const players = Array.isArray(payload.players) ? payload.players : [];
+  const playerIds: string[] = [];
+
+  for (const player of players) {
+    const entry = sanitisePlayer(player, capturedAt);
+    if (!entry.steamId || entry.steamId.trim().length === 0) {
+      continue;
+    }
+
+    playerIds.push(entry.steamId);
+
+    await connection.execute(
+      `INSERT INTO players (steam_id, character_name, group_name, position_x, position_y, position_z, rotation_y, health, is_online, last_seen_utc, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         character_name = VALUES(character_name),
+         group_name = VALUES(group_name),
+         position_x = VALUES(position_x),
+         position_y = VALUES(position_y),
+         position_z = VALUES(position_z),
+         rotation_y = VALUES(rotation_y),
+         health = VALUES(health),
+         is_online = VALUES(is_online),
+         last_seen_utc = VALUES(last_seen_utc),
+         updated_at = VALUES(updated_at)`,
+      [
+        entry.steamId,
+        entry.characterName,
+        entry.groupName,
+        entry.position.x,
+        entry.position.y,
+        entry.position.z,
+        entry.rotationY,
+        entry.health,
+        entry.isOnline ? 1 : 0,
+        entry.lastSeenUtc.slice(0, 19).replace("T", " "),
+        capturedAt.toISOString().slice(0, 19).replace("T", " ")
+      ]
+    );
+  }
+
+  if (playerIds.length > 0) {
+    const placeholders = playerIds.map(() => "?").join(", ");
+    await connection.execute(
+      `UPDATE players SET is_online = 0 WHERE steam_id NOT IN (${placeholders})`,
+      playerIds
+    );
+  } else {
+    await connection.execute("UPDATE players SET is_online = 0");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const configuredKey = process.env.LIVE_SYNC_SERVER_KEY;
+  const presentedKey = request.headers.get("x-server-key");
+
+  if (!configuredKey || presentedKey !== configuredKey) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let payload: IncomingPayload;
+  try {
+    payload = (await request.json()) as IncomingPayload;
+  } catch (error) {
+    console.error("[TempestMap] Failed to parse live payload", error);
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const pool = getDatabase();
+  const connection = await pool.getConnection();
+
+  try {
+    await connection.beginTransaction();
+    await persistSnapshot(connection, payload);
+    await connection.commit();
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    await connection.rollback();
+    console.error("[TempestMap] Failed to persist live snapshot", error);
+    return NextResponse.json({ error: "Failed to persist live snapshot" }, { status: 500 });
+  } finally {
+    connection.release();
+  }
+}

--- a/tempest-map/app/globals.css
+++ b/tempest-map/app/globals.css
@@ -17,6 +17,28 @@ body {
     radial-gradient(circle at bottom right, rgba(3, 7, 18, 0.9), rgba(3, 7, 18, 0.95));
 }
 
+.leaflet-container {
+  font: inherit;
+}
+
+.tempest-map {
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.98));
+}
+
+.leaflet-tooltip {
+  background: rgba(15, 23, 42, 0.9);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+}
+
+.leaflet-tooltip::before {
+  border-top-color: rgba(15, 23, 42, 0.9);
+}
+
 a {
   color: inherit;
 }

--- a/tempest-map/app/layout.tsx
+++ b/tempest-map/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import "./globals.css";
+import "leaflet/dist/leaflet.css";
 
 export const metadata: Metadata = {
   title: "Tempest Tactical Map",

--- a/tempest-map/app/map/page.tsx
+++ b/tempest-map/app/map/page.tsx
@@ -26,7 +26,8 @@ export default function MapPage() {
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-3">
           <h1 className="text-3xl font-semibold tracking-tight text-white">Tempest Tactical Map</h1>
           <p className="text-sm text-slate-300">
-            Live player positions refreshed every {Math.max(5, Number(process.env.TEMPEST_MAP_REFRESH_SECONDS ?? 5))} seconds.
+            Live player positions refreshed every {Math.max(5, Number(process.env.TEMPEST_MAP_REFRESH_SECONDS ?? 5))} seconds via
+            the secured Codex ingest API.
           </p>
         </div>
       </div>

--- a/tempest-map/components/leaflet-canvas.tsx
+++ b/tempest-map/components/leaflet-canvas.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { MapContainer, CircleMarker, Tooltip, SVGOverlay, useMap } from "react-leaflet";
+import { CRS, LatLngBounds } from "leaflet";
+import type { PlayerSnapshot, PlayerPosition } from "@/lib/positions";
+
+type LatLng = [number, number];
+
+type LeafletCanvasProps = {
+  snapshot: PlayerSnapshot;
+};
+
+function projectPosition(position: PlayerPosition["position"], levelSize: number): LatLng {
+  const half = levelSize / 2;
+  const latitude = half - position.z;
+  const longitude = position.x + half;
+  return [latitude, longitude];
+}
+
+function FitBounds({ levelSize }: { levelSize: number }) {
+  const map = useMap();
+
+  useEffect(() => {
+    const bounds = new LatLngBounds([0, 0], [levelSize, levelSize]);
+    map.fitBounds(bounds, { padding: [40, 40] });
+    map.setMaxBounds(bounds.pad(0.1));
+  }, [map, levelSize]);
+
+  return null;
+}
+
+function GridOverlay({ levelSize }: { levelSize: number }) {
+  const bounds: [[number, number], [number, number]] = useMemo(() => [[0, 0], [levelSize, levelSize]], [levelSize]);
+  const lines = useMemo(() => Array.from({ length: 10 }, (_, index) => index + 1), []);
+
+  return (
+    <SVGOverlay bounds={bounds}>
+      <svg viewBox={`0 0 ${levelSize} ${levelSize}`} xmlns="http://www.w3.org/2000/svg">
+        <rect width="100%" height="100%" fill="url(#gridGradient)" />
+        <defs>
+          <radialGradient id="gridGradient" cx="0%" cy="0%" r="120%">
+            <stop offset="0%" stopColor="rgba(56,189,248,0.18)" />
+            <stop offset="60%" stopColor="rgba(15,23,42,0.85)" />
+          </radialGradient>
+        </defs>
+        {lines.map((line) => {
+          const offset = (line / 10) * levelSize;
+          return (
+            <g key={line}>
+              <line x1="0" y1={offset} x2={levelSize} y2={offset} stroke="rgba(148,163,184,0.2)" strokeWidth={1} />
+              <line x1={offset} y1="0" x2={offset} y2={levelSize} stroke="rgba(148,163,184,0.2)" strokeWidth={1} />
+            </g>
+          );
+        })}
+      </svg>
+    </SVGOverlay>
+  );
+}
+
+function PlayerMarker({ player, levelSize }: { player: PlayerPosition; levelSize: number }) {
+  const center = projectPosition(player.position, levelSize);
+  const color = player.isOnline ? "#38bdf8" : "#475569";
+  const fillOpacity = player.isOnline ? 0.65 : 0.35;
+
+  return (
+    <CircleMarker center={center} pathOptions={{ color, weight: 2, fillColor: color, fillOpacity }} radius={8}>
+      <Tooltip direction="top" offset={[0, -12]} opacity={1} permanent={false}>
+        <div className="min-w-[180px] space-y-1 text-xs">
+          <div className="font-semibold text-white">{player.characterName}</div>
+          <div className="text-[0.65rem] uppercase tracking-[0.35em] text-slate-400">
+            {player.groupName ?? "Lone Wolf"}
+          </div>
+          <div className="text-slate-200">Health · {player.health}%</div>
+          <div className="text-slate-300">
+            Pos · {player.position.x.toFixed(1)}, {player.position.y.toFixed(1)}, {player.position.z.toFixed(1)}
+          </div>
+          <div className="text-slate-400">Facing · {player.rotationY.toFixed(0)}°</div>
+        </div>
+      </Tooltip>
+    </CircleMarker>
+  );
+}
+
+export default function LeafletCanvas({ snapshot }: LeafletCanvasProps) {
+  const levelSize = snapshot.metadata.levelSize > 0 ? snapshot.metadata.levelSize : 4096;
+  const bounds: [[number, number], [number, number]] = useMemo(
+    () => [[0, 0], [levelSize, levelSize]],
+    [levelSize]
+  );
+
+  return (
+    <div className="relative flex flex-1 flex-col">
+      <div className="relative flex flex-1 overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80">
+        <MapContainer
+          key={levelSize}
+          className="tempest-map"
+          crs={CRS.Simple}
+          bounds={bounds}
+          zoomControl={false}
+          scrollWheelZoom
+          style={{ height: "100%", width: "100%" }}
+        >
+          <FitBounds levelSize={levelSize} />
+          <GridOverlay levelSize={levelSize} />
+          {snapshot.players.map((player) => (
+            <PlayerMarker key={player.steamId} player={player} levelSize={levelSize} />
+          ))}
+        </MapContainer>
+        {snapshot.players.length === 0 && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs uppercase tracking-[0.4em] text-slate-400">
+            Awaiting live telemetry…
+          </div>
+        )}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent p-4 text-right text-[0.6rem] uppercase tracking-[0.35em] text-slate-400">
+          Coordinates locked · Scale 1 : {levelSize}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tempest-map/components/map-legend.tsx
+++ b/tempest-map/components/map-legend.tsx
@@ -1,4 +1,5 @@
 import { formatDistanceToNowStrict } from "date-fns";
+import Link from "next/link";
 import clsx from "clsx";
 import type { PlayerSnapshot } from "@/lib/positions";
 
@@ -19,6 +20,16 @@ export default function MapLegend({ snapshot }: { snapshot: PlayerSnapshot }) {
         <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
           Last sync · {formatRelative(snapshot.metadata.lastSyncedUtc)} · Level size {snapshot.metadata.levelSize}
         </p>
+        {snapshot.metadata.shareUrl && (
+          <Link
+            href={snapshot.metadata.shareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-flex text-[0.65rem] uppercase tracking-[0.35em] text-brand-200 transition hover:text-brand-100"
+          >
+            Open public map ↗
+          </Link>
+        )}
       </div>
       <div className="space-y-3">
         <h3 className="text-xs uppercase tracking-[0.35em] text-slate-400">Active Squads</h3>
@@ -46,8 +57,21 @@ export default function MapLegend({ snapshot }: { snapshot: PlayerSnapshot }) {
                     {player.groupName ?? "Lone Wolf"}
                   </span>
                 </div>
-                <div className="text-right text-xs text-slate-300">
-                  <div>{isOnline ? "Online" : "Offline"}</div>
+                <div className="flex flex-col items-end gap-1 text-right text-xs text-slate-300">
+                  <div className="flex items-center gap-2 text-[0.7rem] uppercase tracking-[0.4em]">
+                    <span className={clsx("inline-flex h-2 w-2 rounded-full", isOnline ? "bg-brand-300" : "bg-slate-500")} />
+                    {isOnline ? "Online" : "Offline"}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[0.65rem] uppercase tracking-[0.4em] text-slate-500">Health</span>
+                    <div className="flex h-2 w-20 overflow-hidden rounded-full border border-white/10">
+                      <div
+                        className={clsx("h-full transition", isOnline ? "bg-brand-300" : "bg-slate-600")}
+                        style={{ width: `${Math.min(100, Math.max(0, player.health))}%` }}
+                      />
+                    </div>
+                    <span className="text-[0.65rem] text-slate-200">{player.health}%</span>
+                  </div>
                   <div className="text-[0.7rem] uppercase tracking-[0.4em] text-slate-500">
                     {formatRelative(player.lastSeenUtc)}
                   </div>
@@ -62,7 +86,7 @@ export default function MapLegend({ snapshot }: { snapshot: PlayerSnapshot }) {
         <p>
           Positions are expressed using the Unturned world coordinate system. Hover or tap on a player marker to reveal
           exact values alongside facing direction. Data is refreshed on a {Number(process.env.TEMPEST_MAP_REFRESH_SECONDS ?? 5)}
-          second cadence directly from the Tempest plugin bridge.
+          second cadence directly from the Tempest live sync bridge.
         </p>
       </div>
     </div>

--- a/tempest-map/components/map-viewport.tsx
+++ b/tempest-map/components/map-viewport.tsx
@@ -1,20 +1,27 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-import clsx from "clsx";
-import type { PlayerSnapshot, PlayerPosition } from "@/lib/positions";
+import { useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import type { PlayerSnapshot } from "@/lib/positions";
 
 const REFRESH_INTERVAL = Number(process.env.NEXT_PUBLIC_TEMPEST_MAP_REFRESH_MS ?? 5000);
+
+const LeafletCanvas = dynamic(() => import("@/components/leaflet-canvas"), { ssr: false });
+
+type MapViewportProps = {
+  snapshot: PlayerSnapshot;
+};
 
 function useLiveSnapshot(initial: PlayerSnapshot) {
   const [snapshot, setSnapshot] = useState<PlayerSnapshot>(initial);
 
   const refresh = useCallback(async () => {
     try {
-      const response = await fetch("/api/map", { cache: "no-store" });
+      const response = await fetch("/api/live", { cache: "no-store" });
       if (!response.ok) {
         throw new Error(`Failed to refresh tactical map: ${response.status}`);
       }
+
       const payload = (await response.json()) as PlayerSnapshot;
       setSnapshot(payload);
     } catch (error) {
@@ -27,89 +34,14 @@ function useLiveSnapshot(initial: PlayerSnapshot) {
   }, [initial]);
 
   useEffect(() => {
-    const interval = setInterval(refresh, Math.max(1500, REFRESH_INTERVAL));
-    return () => clearInterval(interval);
+    const interval = window.setInterval(refresh, Math.max(1500, REFRESH_INTERVAL));
+    return () => window.clearInterval(interval);
   }, [refresh]);
 
   return snapshot;
 }
 
-function projectCoordinate(value: number, levelSize: number) {
-  const halfSize = levelSize / 2;
-  const clamped = Math.max(-halfSize, Math.min(halfSize, value));
-  const normalised = (clamped + halfSize) / levelSize;
-  return Math.round(normalised * 1000) / 10; // percentage with single decimal
-}
-
-function PlayerMarker({ player, levelSize }: { player: PlayerPosition; levelSize: number }) {
-  const top = 100 - projectCoordinate(player.position.z, levelSize);
-  const left = projectCoordinate(player.position.x, levelSize);
-  const rotation = player.rotationY;
-
-  return (
-    <div
-      className={clsx(
-        "group absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 text-xs",
-        player.isOnline ? "text-brand-100" : "text-slate-500"
-      )}
-      style={{ top: `${top}%`, left: `${left}%` }}
-    >
-      <span
-        className={clsx(
-          "relative flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold transition",
-          player.isOnline
-            ? "border-brand-300/60 bg-brand-500/20 shadow-lg shadow-brand-500/20"
-            : "border-white/10 bg-white/5"
-        )}
-        style={{ transform: `rotate(${rotation}deg)` }}
-        title={`${player.characterName}\n(${player.position.x.toFixed(1)}, ${player.position.y.toFixed(1)}, ${player.position.z.toFixed(1)})`}
-      >
-        <span className="pointer-events-none select-none" style={{ transform: `rotate(${-rotation}deg)` }}>
-          ▲
-        </span>
-      </span>
-      <div className="rounded-full bg-slate-900/80 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em]">
-        {player.characterName}
-      </div>
-    </div>
-  );
-}
-
-function BackgroundGrid() {
-  const lines = useMemo(() => Array.from({ length: 10 }, (_, index) => index + 1), []);
-  return (
-    <div className="absolute inset-0 overflow-hidden rounded-2xl">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(51,210,255,0.12),transparent_55%)]" />
-      <div className="absolute inset-0 bg-slate-900/50" />
-      <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
-        {lines.map((line) => (
-          <Fragment key={line}>
-            <line x1="0" x2="100%" y1={`${(line / 10) * 100}%`} y2={`${(line / 10) * 100}%`} stroke="rgba(148, 163, 184, 0.15)" strokeWidth="1" />
-            <line y1="0" y2="100%" x1={`${(line / 10) * 100}%`} x2={`${(line / 10) * 100}%`} stroke="rgba(148, 163, 184, 0.15)" strokeWidth="1" />
-          </Fragment>
-        ))}
-      </svg>
-    </div>
-  );
-}
-
-export default function MapViewport({ snapshot: initialSnapshot }: { snapshot: PlayerSnapshot }) {
+export default function MapViewport({ snapshot: initialSnapshot }: MapViewportProps) {
   const snapshot = useLiveSnapshot(initialSnapshot);
-  const levelSize = snapshot.metadata.levelSize || 4096;
-
-  return (
-    <div className="relative flex flex-1 flex-col">
-      <div className="relative flex flex-1 items-stretch overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80">
-        <BackgroundGrid />
-        <div className="relative z-10 h-full w-full">
-          {snapshot.players.map((player) => (
-            <PlayerMarker key={player.steamId} player={player} levelSize={levelSize} />
-          ))}
-        </div>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent p-4 text-right text-[0.6rem] uppercase tracking-[0.35em] text-slate-400">
-          Coordinates locked · Scale 1 : {levelSize}
-        </div>
-      </div>
-    </div>
-  );
+  return <LeafletCanvas snapshot={snapshot} />;
 }

--- a/tempest-map/package-lock.json
+++ b/tempest-map/package-lock.json
@@ -8,15 +8,16 @@
       "name": "tempest-map",
       "version": "0.1.0",
       "dependencies": {
-        "better-sqlite3": "^11.3.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "leaflet": "^1.9.4",
+        "mysql2": "^3.10.3",
         "next": "14.2.5",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
@@ -494,6 +495,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -533,16 +545,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/json5": {
@@ -1352,6 +1354,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
@@ -1379,26 +1390,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
@@ -1407,17 +1398,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/binary-extensions": {
@@ -1431,26 +1411,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1509,30 +1469,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/busboy": {
@@ -1690,12 +1626,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -1873,30 +1803,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1940,13 +1846,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10"
       }
     },
     "node_modules/didyoumean": {
@@ -2024,15 +1930,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -2681,15 +2578,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2763,12 +2651,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2869,12 +2751,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2936,6 +2812,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/generator-function": {
@@ -3017,12 +2902,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.3.10",
@@ -3260,25 +3139,21 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3333,12 +3208,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -3646,6 +3516,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3951,6 +3827,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4008,6 +3890,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4018,6 +3906,30 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4054,18 +3966,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4083,6 +3983,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4098,18 +3999,32 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.1.tgz",
+      "integrity": "sha512-WZMIRZstT2MFfouEaDz/AGFnGi1A2GwaDe7XvKTdRJEYiAHbOrh4S3d8KFmQeh11U85G+BFjIvS1Di5alusZsw==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -4121,6 +4036,18 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -4140,12 +4067,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -4246,18 +4167,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.77.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
-      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-releases": {
@@ -4424,6 +4333,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4793,32 +4703,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4839,16 +4723,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4882,30 +4756,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4938,6 +4788,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4946,20 +4810,6 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -5154,26 +5004,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5209,6 +5039,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -5222,6 +5058,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5229,6 +5066,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5391,51 +5233,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5453,6 +5250,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/stable-hash": {
@@ -5482,15 +5288,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -5836,34 +5633,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5993,18 +5762,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6230,6 +5987,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {
@@ -6452,6 +6210,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/tempest-map/package.json
+++ b/tempest-map/package.json
@@ -9,15 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "better-sqlite3": "^11.3.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "leaflet": "^1.9.4",
+    "mysql2": "^3.10.3",
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",


### PR DESCRIPTION
## Summary
- update the Rocket plugin map bridge to stream live player/map snapshots to the Codex ingest endpoint with API key auth
- add Next.js server routes and MySQL persistence for incoming telemetry plus a public /api/live feed
- refresh the tactical map UI with Leaflet-based markers, new dependencies, and updated documentation/env configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2dcca763c8324be41bd0f02a4f043