### PR TITLE
Handle Tempest map database outages gracefully

### DIFF
--- a/ARC_TPA_Commands.csproj
+++ b/ARC_TPA_Commands.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>a3966d7f-9bed-427f-a15e-e097b50871be</ProjectGuid>
+    <ProjectGuid>{A3966D7F-9BED-427F-A15E-E097B50871BE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ARC_TPA_Commands</RootNamespace>
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,87 +32,47 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System"/>
-    
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
-    
-    
-    <Reference Include="Microsoft.CSharp"/>
-    
-    <Reference Include="System.Data"/>
-    
-    <Reference Include="System.Net.Http"/>
-
-    <Reference Include="System.Web.Extensions"/>
-
-    <Reference Include="System.Xml"/>
-
-
-
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml" />
     <Reference Include="Rocket.API">
-
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Extras\Rocket.Unturned\Rocket.API.dll</HintPath>
-
       <Private>false</Private>
-
     </Reference>
-
     <Reference Include="Rocket.Core">
-
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Extras\Rocket.Unturned\Rocket.Core.dll</HintPath>
-
       <Private>false</Private>
-
     </Reference>
-
     <Reference Include="Rocket.Unturned">
-
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Extras\Rocket.Unturned\Rocket.Unturned.dll</HintPath>
-
       <Private>false</Private>
-
     </Reference>
-
     <Reference Include="Assembly-CSharp">
-
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Unturned_Data\Managed\Assembly-CSharp.dll</HintPath>
-
       <Private>false</Private>
-
     </Reference>
-
     <Reference Include="UnityEngine.CoreModule">
-
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Unturned_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-
       <Private>false</Private>
-
     </Reference>
-
+    <Reference Include="com.rlabrecque.steamworks.net">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Unturned_Data\Managed\com.rlabrecque.steamworks.net.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Class1.cs" />
     <Compile Include="TempestMapService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-      <Private>false</Private>
-    </Reference>
-
-    <Reference Include="com.rlabrecque.steamworks.net">
-
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Unturned\Unturned_Data\Managed\com.rlabrecque.steamworks.net.dll</HintPath>
-
-      <Private>false</Private>
-
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
- </Project>
+</Project>
 
 
 

--- a/tempest-map/README.md
+++ b/tempest-map/README.md
@@ -24,7 +24,7 @@ TEMPEST_USE_MOCK_DB=false
 
 The Rocket plugin will stream telemetry to `POST /api/unturned/live` with the `X-Server-Key` header set to `LIVE_SYNC_SERVER_KEY`. The Next.js `GET /api/live` endpoint (and the `/map` page) query the same database to power the Leaflet dashboard.
 
-For local development without a MySQL server, set `TEMPEST_USE_MOCK_DB=true` to bypass all database access and serve the built-in mock telemetry while keeping the ingest API disabled. This prevents noisy connection errors when the database is intentionally unavailable.
+For local development without a MySQL server, set `TEMPEST_USE_MOCK_DB=true` to bypass all database access and serve the built-in mock telemetry while keeping the ingest API disabled. This prevents noisy connection errors when the database is intentionally unavailable. Fatal connection errors now automatically disable database access until the process restarts, so the mock telemetry continues to power the UI without repeated console spam.
 
 ## Available scripts
 

--- a/tempest-map/lib/positions.ts
+++ b/tempest-map/lib/positions.ts
@@ -1,4 +1,4 @@
-import { getDatabase, isDatabaseEnabled } from "@/lib/db";
+import { getDatabase, handleDatabaseError, isDatabaseEnabled } from "@/lib/db";
 import { ensureLiveSchema } from "@/lib/schema";
 import type { RowDataPacket } from "mysql2";
 
@@ -138,6 +138,7 @@ export async function fetchPlayerSnapshot(): Promise<PlayerSnapshot> {
       players
     } satisfies PlayerSnapshot;
   } catch (error) {
+    handleDatabaseError(error, "Live snapshot query");
     console.error("[TempestMap] Failed to query database, returning mock snapshot.", error);
     return createMockSnapshot();
   }

--- a/tempest-map/package-lock.json
+++ b/tempest-map/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-config-next": "14.2.5",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.4",
-        "typescript": "^5.4.5"
+        "typescript": "5.4.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5886,9 +5886,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tempest-map/package.json
+++ b/tempest-map/package.json
@@ -28,6 +28,6 @@
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- fix the Visual Studio project file so the solution loads without XML errors
- add defensive database failure handling for the Tempest map service and document the fallback behaviour
- pin the TypeScript toolchain to a supported version to eliminate lint warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2e7f607488324a218f0fe98d944f8