### PR TITLE
Ensure Tempest map build step applies database schema

### DIFF
--- a/tempest-map/README.md
+++ b/tempest-map/README.md
@@ -29,7 +29,7 @@ For local development without a MySQL server, set `TEMPEST_USE_MOCK_DB=true` to 
 ## Available scripts
 
 - `npm run dev` – run the development server with hot reload.
-- `npm run build` – compile for production.
+- `npm run build` – compile for production (automatically ensures the MySQL schema exists first).
 - `npm run start` – launch the production build.
 - `npm run lint` – run ESLint checks.
 

--- a/tempest-map/package.json
+++ b/tempest-map/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",
+    "prebuild": "node scripts/apply-schema.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/tempest-map/scripts/apply-schema.mjs
+++ b/tempest-map/scripts/apply-schema.mjs
@@ -1,0 +1,90 @@
+import mysql from "mysql2/promise";
+
+function parseBoolean(value) {
+  return value ? value.toLowerCase() === "true" : false;
+}
+
+function parseNumber(value, fallback) {
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  return fallback;
+}
+
+async function ensureSchema() {
+  if (parseBoolean(process.env.TEMPEST_USE_MOCK_DB)) {
+    console.log("[TempestMap] Database schema skipped (mock DB enabled).");
+    return;
+  }
+
+  const host = process.env.MYSQL_HOST ?? "127.0.0.1";
+  const port = parseNumber(process.env.MYSQL_PORT, 3306);
+  const user = process.env.MYSQL_USER ?? "tempest";
+  const password = process.env.MYSQL_PASSWORD ?? "";
+  const database = process.env.MYSQL_DATABASE ?? "tempest_map";
+
+  const pool = mysql.createPool({
+    host,
+    port,
+    user,
+    password,
+    database,
+    waitForConnections: true,
+    connectionLimit: 2,
+    queueLimit: 0,
+    dateStrings: true
+  });
+
+  let connection;
+
+  try {
+    connection = await pool.getConnection();
+
+    await connection.query(`
+      CREATE TABLE IF NOT EXISTS map_state (
+        id TINYINT UNSIGNED NOT NULL PRIMARY KEY,
+        map_name VARCHAR(120) NOT NULL,
+        level_size INT NOT NULL,
+        last_synced_utc DATETIME NOT NULL,
+        share_url VARCHAR(255) NULL
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    `);
+
+    await connection.query(`
+      CREATE TABLE IF NOT EXISTS players (
+        steam_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+        character_name VARCHAR(120) NOT NULL,
+        group_name VARCHAR(120) NULL,
+        position_x DOUBLE NOT NULL,
+        position_y DOUBLE NOT NULL,
+        position_z DOUBLE NOT NULL,
+        rotation_y DOUBLE NOT NULL,
+        health TINYINT UNSIGNED NOT NULL,
+        is_online TINYINT(1) NOT NULL DEFAULT 0,
+        last_seen_utc DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        INDEX idx_players_last_seen (last_seen_utc),
+        INDEX idx_players_online (is_online)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    `);
+
+    console.log("[TempestMap] Database schema ensured.");
+  } finally {
+    if (connection) {
+      connection.release();
+    }
+
+    await pool.end();
+  }
+}
+
+ensureSchema().catch((error) => {
+  console.error("[TempestMap] Failed to ensure database schema.", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a build pre-step that ensures the MySQL schema exists before compiling the tactical map
- document the automatic schema application in the tactical map README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2ea2710e08324bee7a309214b4a8b