### PR TITLE
Expose database disable reason and surface mock telemetry banner

### DIFF
--- a/tempest-map/components/map-legend.tsx
+++ b/tempest-map/components/map-legend.tsx
@@ -20,6 +20,15 @@ export default function MapLegend({ snapshot }: { snapshot: PlayerSnapshot }) {
         <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
           Last sync · {formatRelative(snapshot.metadata.lastSyncedUtc)} · Level size {snapshot.metadata.levelSize}
         </p>
+        {snapshot.source === "mock" && (
+          <div className="mt-4 space-y-1 rounded-2xl border border-amber-400/40 bg-amber-500/10 p-4 text-[0.65rem] uppercase tracking-[0.3em] text-amber-200">
+            <p className="font-semibold text-amber-100">Operating on mock telemetry</p>
+            <p className="normal-case text-[0.7rem] tracking-normal text-amber-100/80">
+              {snapshot.disableReason ??
+                "The Tempest database is currently unavailable. Live data will resume once connectivity is restored."}
+            </p>
+          </div>
+        )}
         {snapshot.metadata.shareUrl && (
           <Link
             href={snapshot.metadata.shareUrl}

--- a/tempest-map/lib/db.ts
+++ b/tempest-map/lib/db.ts
@@ -16,6 +16,10 @@ export function isDatabaseEnabled(): boolean {
   return !databaseDisabled;
 }
 
+export function getDatabaseDisableReason(): string | undefined {
+  return disableReason;
+}
+
 function shouldDisableDatabase(error: unknown): error is MysqlError {
   if (!error || typeof error !== "object") {
     return false;


### PR DESCRIPTION
## Summary
- expose the reason database access was disabled so other modules can surface it
- include source metadata in player snapshots and propagate the disable reason through mock payloads
- show a mock telemetry warning banner in the tactical map legend when the UI is backed by fallback data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2f287dbfc83249a70e36c61451dfd