### PR TITLE
Update database configuration to read from .env variables

### DIFF
--- a/tempest-map/.env.example
+++ b/tempest-map/.env.example
@@ -1,3 +1,11 @@
+# Database connection details for the tactical map API
+TEMPEST_MAP_DB_HOST=127.0.0.1
+TEMPEST_MAP_DB_PORT=3306
+TEMPEST_MAP_DB_USER=tempest
+TEMPEST_MAP_DB_PASSWORD=ChangeMe!
+TEMPEST_MAP_DB_NAME=tempest_map
+TEMPEST_MAP_DB_POOL_SIZE=10
+
 # Set to true to disable MySQL access and serve the built-in mock telemetry instead
 TEMPEST_USE_MOCK_DB=true
 

--- a/tempest-map/README.md
+++ b/tempest-map/README.md
@@ -13,11 +13,11 @@ npm run dev
 The development server runs on <http://localhost:3000> by default. Configure the following environment variables to connect both the ingest API and the tactical UI to your MySQL instance:
 
 ```
-MYSQL_HOST=127.0.0.1
-MYSQL_PORT=3306
-MYSQL_USER=tempest
-MYSQL_PASSWORD=ChangeMe!
-MYSQL_DATABASE=tempest_map
+TEMPEST_MAP_DB_HOST=127.0.0.1
+TEMPEST_MAP_DB_PORT=3306
+TEMPEST_MAP_DB_USER=tempest
+TEMPEST_MAP_DB_PASSWORD=ChangeMe!
+TEMPEST_MAP_DB_NAME=tempest_map
 LIVE_SYNC_SERVER_KEY=ChangeMe!
 TEMPEST_USE_MOCK_DB=false
 ```

--- a/tempest-map/lib/db.ts
+++ b/tempest-map/lib/db.ts
@@ -83,12 +83,27 @@ function createDatabase(): TempestDatabase {
     );
   }
 
-  const host = process.env.MYSQL_HOST ?? "127.0.0.1";
-  const port = parseNumber(process.env.MYSQL_PORT, 3306);
-  const user = process.env.MYSQL_USER ?? "tempest";
-  const password = process.env.MYSQL_PASSWORD ?? "";
-  const databaseName = process.env.MYSQL_DATABASE ?? "tempest_map";
-  const connectionLimit = parseNumber(process.env.MYSQL_POOL_LIMIT, 10);
+  const host =
+    process.env.TEMPEST_MAP_DB_HOST?.trim() ||
+    process.env.MYSQL_HOST?.trim() ||
+    "127.0.0.1";
+  const port = parseNumber(process.env.TEMPEST_MAP_DB_PORT ?? process.env.MYSQL_PORT, 3306);
+  const user =
+    process.env.TEMPEST_MAP_DB_USER?.trim() ||
+    process.env.MYSQL_USER?.trim() ||
+    "tempest";
+  const password =
+    process.env.TEMPEST_MAP_DB_PASSWORD ??
+    process.env.MYSQL_PASSWORD ??
+    "";
+  const databaseName =
+    process.env.TEMPEST_MAP_DB_NAME?.trim() ||
+    process.env.MYSQL_DATABASE?.trim() ||
+    "tempest_map";
+  const connectionLimit = parseNumber(
+    process.env.TEMPEST_MAP_DB_POOL_SIZE ?? process.env.MYSQL_POOL_LIMIT,
+    10
+  );
 
   return mysql.createPool({
     host,


### PR DESCRIPTION
## Summary
- allow the tactical map database pool to read credentials from the TEMPEST_MAP_DB_* environment variables defined in .env files
- update the example environment file and documentation to include the new database settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2f4e9942c8324b3e1d5c777664348