### PR TITLE
Prevent concurrent modification while building snapshot

### DIFF
--- a/TempestMapService.cs
+++ b/TempestMapService.cs
@@ -219,11 +219,14 @@ namespace ARC_TPA_Commands
 
         private object BuildSnapshot()
         {
-            var clients = Provider.clients ?? new List<SteamPlayer>();
-            var players = new List<object>(clients.Count);
+            var clientsSnapshot = Provider.clients != null
+                ? Provider.clients.ToArray()
+                : Array.Empty<SteamPlayer>();
+
+            var players = new List<object>(clientsSnapshot.Length);
             DateTime capturedAt = DateTime.UtcNow;
 
-            foreach (var steamPlayer in clients.Where(p => p != null && p.player != null))
+            foreach (var steamPlayer in clientsSnapshot.Where(p => p != null && p.player != null))
             {
                 try
                 {


### PR DESCRIPTION
## Summary
- take a snapshot of Provider.clients before iterating when building the live map payload
- size the players list based on the snapshot to avoid race conditions during serialization

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_b_68e2f6f2c2f88324872c99a06e80e228